### PR TITLE
Add example to allow permission without option

### DIFF
--- a/docs/5_declarative-deno-options.md
+++ b/docs/5_declarative-deno-options.md
@@ -24,6 +24,7 @@ scripts:
     cmd: server.ts
     allow: # or a map
       net: 127.0.0.1
+      read: true # allow all reads
 ```
 
 ## Tsconfig


### PR DESCRIPTION
This PR will add a simple example to the docs, that shows how to omit the optional argument of permissions.