### PR TITLE
Updates version of package used in typescript config docs

### DIFF
--- a/docs/11_vscode.md
+++ b/docs/11_vscode.md
@@ -15,7 +15,7 @@ code assistance for script configuration files (both `yaml` and `json`).
 To get code assistance in TypeScript config files, add a type to the default export:
 
 ```typescript
-import { ScriptsConfiguration } from "https://deno.land/x/velociraptor@1.0.0-beta.17/mod.ts";
+import { ScriptsConfiguration } from "https://deno.land/x/velociraptor@1.5.0/mod.ts";
 
 export default <ScriptsConfiguration>{
   scripts: {


### PR DESCRIPTION
I ran into a few bugs before realizing the docs used for the typescript config types are out of date. This is just a small change to use version 1.5.0

Might be worth considering some better approaches to keeping versioned imports in docs up to date or removing them entirely.